### PR TITLE
feature(ui-shell): right panel state management

### DIFF
--- a/packages/react/src/components/UIShell/HeaderContainer.js
+++ b/packages/react/src/components/UIShell/HeaderContainer.js
@@ -28,7 +28,7 @@ const HeaderContainer = ({ isSideNavExpanded, render: Children }) => {
 
 HeaderContainer.propTypes = {
   /**
-   * Optionally provide a custom class name that is applied to the underlying <header>
+   * Optionally provide initial state for expandable sidenav
    */
   isSideNavExpanded: PropTypes.bool,
 };

--- a/packages/react/src/components/UIShell/HeaderContainer.js
+++ b/packages/react/src/components/UIShell/HeaderContainer.js
@@ -8,20 +8,33 @@
 import PropTypes from 'prop-types';
 import React, { useState, useCallback } from 'react';
 
-const HeaderContainer = ({ isSideNavExpanded, render: Children }) => {
+const HeaderContainer = ({
+  isSideNavExpanded,
+  render: Children,
+  activeGlobalAction,
+}) => {
   //state for expandable sidenav
   const [isSideNavExpandedState, setIsSideNavExpandedState] = useState(
     isSideNavExpanded
+  );
+  const [activeGlobalActionState, setActiveGlobalActionState] = useState(
+    activeGlobalAction
   );
 
   const handleHeaderMenuButtonClick = useCallback(() => {
     setIsSideNavExpandedState(!isSideNavExpandedState);
   }, [isSideNavExpandedState, setIsSideNavExpandedState]);
 
+  const handleChangeGlobalAction = globalAction => {
+    setActiveGlobalActionState(globalAction);
+  };
+
   return (
     <Children
       isSideNavExpanded={isSideNavExpandedState}
       onClickSideNavExpand={handleHeaderMenuButtonClick}
+      activeGlobalAction={activeGlobalActionState}
+      onChangeGlobalAction={handleChangeGlobalAction}
     />
   );
 };
@@ -31,6 +44,11 @@ HeaderContainer.propTypes = {
    * Optionally provide initial state for expandable sidenav
    */
   isSideNavExpanded: PropTypes.bool,
+
+  /**
+   * Optionally provide globalAction to be active initially
+   */
+  activeGlobalAction: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 HeaderContainer.defaultProps = {


### PR DESCRIPTION
Have the HeaderContainer keep track of whether or not the right side panel (HeaderPanel) is open, in the same way that it does for the sidenav. Because the HeaderPanel context is linked to different global actions, we keep track of which action is active instead of just tracking expanded/closed state.

#### Changelog

**New**

- Added state to track global actions in the UI shell container (HeaderContainer.js). 

**Changed**

- Updated comment for the "isSideNavExpanded" prop type to actually refer to the prop.
