### PR TITLE
feat(floating-menu): custom viewport offset

### DIFF
--- a/packages/react/src/components/OverflowMenu/OverflowMenu-story.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu-story.js
@@ -140,4 +140,40 @@ storiesOf('OverflowMenu', module)
           `,
       },
     }
+  )
+  .add(
+    'custom viewport',
+    withReadme(OverflowREADME, () => (
+      <div
+        id="overflow-menu-custom-viewport-container"
+        style={{
+          border: '1px solid black',
+          width: 400,
+          height: 400,
+          overflow: 'scroll',
+          position: 'absolute',
+          top: 200,
+          left: 200,
+        }}>
+        <div data-floating-menu-container>
+          <OverflowMenuExample
+            overflowMenuProps={{
+              ...props.menu(),
+              getViewport: () =>
+                document.getElementById(
+                  'overflow-menu-custom-viewport-container'
+                ),
+            }}
+            overflowMenuItemProps={props.menuItem()}
+          />
+        </div>
+      </div>
+    )),
+    {
+      info: {
+        text: `
+         A custom viewport can be specified to make sure that the menu is offset correctly when the floating menu container is within some absolutely positioned element with it's own scrolling behavior.
+          `,
+      },
+    }
   );

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -203,6 +203,11 @@ class OverflowMenu extends Component {
      * Function called when menu is closed
      */
     onOpen: PropTypes.func,
+
+    /**
+     * Optional callback used to obtain a custom 'viewport' that differs from the window.
+     */
+    getViewport: PropTypes.func,
   };
 
   static defaultProps = {
@@ -453,6 +458,7 @@ class OverflowMenu extends Component {
       renderIcon: IconElement,
       innerRef: ref,
       menuOptionsClass,
+      getViewport,
       ...other
     } = this.props;
 
@@ -507,6 +513,7 @@ class OverflowMenu extends Component {
         menuPosition={this.state.menuPosition}
         menuDirection={direction}
         menuOffset={flipped ? menuOffsetFlip : menuOffset}
+        getViewport={getViewport}
         menuRef={this._bindMenuBody}
         menuEl={this.menuEl}
         flipped={this.props.flipped}

--- a/packages/react/src/components/Tooltip/Tooltip-story.js
+++ b/packages/react/src/components/Tooltip/Tooltip-story.js
@@ -202,4 +202,51 @@ storiesOf('Tooltip', module)
       },
     }
   )
-  .add('uncontrolled tooltip', () => <UncontrolledTooltipExample />);
+  .add('uncontrolled tooltip', () => <UncontrolledTooltipExample />)
+  .add(
+    'custom viewport',
+    () => (
+      <div
+        id="overflow-menu-custom-viewport-container"
+        style={{
+          border: '1px solid black',
+          width: 400,
+          height: 400,
+          overflow: 'scroll',
+          position: 'absolute',
+          top: 200,
+          left: 200,
+        }}>
+        <div data-floating-menu-container>
+          <div style={{ marginTop: '2rem' }}>
+            <Tooltip
+              {...props.withIcon()}
+              getViewport={() =>
+                document.getElementById(
+                  'overflow-menu-custom-viewport-container'
+                )
+              }>
+              <p>
+                This is some tooltip text. This box shows the maximum amount of
+                text that should appear inside. If more room is needed please
+                use a modal instead.
+              </p>
+              <div className={`${prefix}--tooltip__footer`}>
+                <a href="/" className={`${prefix}--link`}>
+                  Learn More
+                </a>
+                <Button size="small">Create</Button>
+              </div>
+            </Tooltip>
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      info: {
+        text: `
+            A custom viewport can be specified to make sure that the menu is offset correctly when the floating menu container is within some absolutely positioned element with it's own scrolling behavior.
+          `,
+      },
+    }
+  );

--- a/packages/react/src/components/Tooltip/Tooltip.js
+++ b/packages/react/src/components/Tooltip/Tooltip.js
@@ -188,6 +188,11 @@ class Tooltip extends Component {
     onChange: !useControlledStateWithValue
       ? PropTypes.func
       : requiredIfValueExists(PropTypes.func),
+
+    /**
+     * Optional callback used to obtain a custom 'viewport' that differs from the window.
+     */
+    getViewport: PropTypes.func,
   };
 
   static defaultProps = {
@@ -379,6 +384,7 @@ class Tooltip extends Component {
       menuOffset,
       tabIndex = 0,
       innerRef: ref,
+      getViewport,
       ...other
     } = this.props;
 
@@ -451,6 +457,7 @@ class Tooltip extends Component {
             menuPosition={this.state.triggerPosition}
             menuDirection={direction}
             menuOffset={menuOffset}
+            getViewport={getViewport}
             menuRef={node => {
               this._tooltipEl = node;
             }}>

--- a/packages/react/src/components/UIShell/HeaderContainer.js
+++ b/packages/react/src/components/UIShell/HeaderContainer.js
@@ -34,7 +34,7 @@ const HeaderContainer = ({
       isSideNavExpanded={isSideNavExpandedState}
       onClickSideNavExpand={handleHeaderMenuButtonClick}
       activeGlobalAction={activeGlobalActionState}
-      onChangeGlobalAction={handleChangeGlobalAction}
+      changeGlobalActionTo={handleChangeGlobalAction}
     />
   );
 };

--- a/packages/react/src/components/UIShell/UIShell-story.js
+++ b/packages/react/src/components/UIShell/UIShell-story.js
@@ -470,30 +470,52 @@ storiesOf('UI Shell', module)
   .add(
     'Header Base w/ Actions and Right Panel',
     withReadme(readme, () => (
-      <Header aria-label="IBM Platform Name">
-        <HeaderName href="#" prefix="IBM">
-          [Platform]
-        </HeaderName>
-        <HeaderGlobalBar>
-          <HeaderGlobalAction
-            aria-label="Search"
-            onClick={action('search click')}>
-            <Search20 />
-          </HeaderGlobalAction>
-          <HeaderGlobalAction
-            aria-label="Notifications"
-            isActive
-            onClick={action('notification click')}>
-            <Notification20 />
-          </HeaderGlobalAction>
-          <HeaderGlobalAction
-            aria-label="App Switcher"
-            onClick={action('app-switcher click')}>
-            <AppSwitcher20 />
-          </HeaderGlobalAction>
-        </HeaderGlobalBar>
-        <HeaderPanel aria-label="Header Panel" expanded />
-      </Header>
+      <HeaderContainer
+        activeGlobalAction={'none'}
+        render={({ activeGlobalAction, changeGlobalActionTo }) => (
+          <Header aria-label="IBM Platform Name">
+            <HeaderName href="#" prefix="IBM">
+              [Platform]
+            </HeaderName>
+            <HeaderGlobalBar>
+              <HeaderGlobalAction
+                aria-label="Search"
+                isActive={activeGlobalAction === 'search'}
+                onClick={() => {
+                  activeGlobalAction === 'search'
+                    ? changeGlobalActionTo('none')
+                    : changeGlobalActionTo('search');
+                }}>
+                <Search20 />
+              </HeaderGlobalAction>
+              <HeaderGlobalAction
+                aria-label="Notifications"
+                isActive={activeGlobalAction === 'notifications'}
+                onClick={() => {
+                  activeGlobalAction === 'notifications'
+                    ? changeGlobalActionTo('none')
+                    : changeGlobalActionTo('notifications');
+                }}>
+                <Notification20 />
+              </HeaderGlobalAction>
+              <HeaderGlobalAction
+                aria-label="App Switcher"
+                isActive={activeGlobalAction === 'app'}
+                onClick={() => {
+                  activeGlobalAction === 'app'
+                    ? changeGlobalActionTo('none')
+                    : changeGlobalActionTo('app');
+                }}>
+                <AppSwitcher20 />
+              </HeaderGlobalAction>
+            </HeaderGlobalBar>
+            <HeaderPanel
+              aria-label="Header Panel"
+              expanded={activeGlobalAction !== 'none'}
+            />
+          </Header>
+        )}
+      />
     ))
   )
   .add(


### PR DESCRIPTION
Allow a custom viewport to be specified so that the floating menu can be correctly positioned even if it's container (or the entire application) are absolutely positioned within some container element (the custom 'viewport').

#### Changelog

**New**

- Add 'getViewport' prop to FloatingMenu. An optional function which returns the viewport which holds the floating menu container.
- Add 'getViewport' props to components which utilize the FloatingMenu, in a similar way to how 'menuOffset' is implemented. Currently only the OverflowMenu and Tooltip implement this.


#### Testing / Reviewing
- WIP storybook stories for the Tooltip/OverflowMenu components were added to showcase the base functionality.
