### PR TITLE
fix(modal): enable clicks outside modal focus trap

### DIFF
--- a/packages/react/src/components/Modal/Modal.js
+++ b/packages/react/src/components/Modal/Modal.js
@@ -131,6 +131,11 @@ export default class Modal extends Component {
     focusTrap: PropTypes.bool,
 
     /**
+     * Specify whether the focus trap should also trap mouse events. By default this is false.
+     */
+    trapMouse: PropTypes.bool,
+
+    /**
      * Required props for the accessibility label of the header
      */
     ...AriaLabelPropType,
@@ -147,6 +152,7 @@ export default class Modal extends Component {
     modalLabel: '',
     selectorPrimaryFocus: '[data-modal-primary-focus]',
     focusTrap: true,
+    trapMouse: false,
   };
 
   button = React.createRef();
@@ -284,6 +290,7 @@ export default class Modal extends Component {
       selectorsFloatingMenus, // eslint-disable-line
       shouldSubmitOnEnter, // eslint-disable-line
       focusTrap,
+      trapMouse,
       ...other
     } = this.props;
 
@@ -384,7 +391,10 @@ export default class Modal extends Component {
       // `<FocusTrap>` has `active: true` in its `defaultProps`
       <FocusTrap
         active={!!open}
-        focusTrapOptions={{ initialFocus: this.initialFocus }}>
+        focusTrapOptions={{
+          initialFocus: this.initialFocus,
+          allowOutsideClick: () => !trapMouse,
+        }}>
         {modal}
       </FocusTrap>
     );

--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -61,6 +61,7 @@ exports[`ModalWrapper should render 1`] = `
         active={false}
         focusTrapOptions={
           Object {
+            "allowOutsideClick: [Function],
             "initialFocus": [Function],
           }
         }

--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -61,7 +61,7 @@ exports[`ModalWrapper should render 1`] = `
         active={false}
         focusTrapOptions={
           Object {
-            "allowOutsideClick: [Function],
+            "allowOutsideClick": [Function],
             "initialFocus": [Function],
           }
         }

--- a/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
+++ b/packages/react/src/components/ModalWrapper/__snapshots__/ModalWrapper-test.js.snap
@@ -55,6 +55,7 @@ exports[`ModalWrapper should render 1`] = `
       primaryButtonText="Save"
       secondaryButtonText="Cancel"
       selectorPrimaryFocus="[data-modal-primary-focus]"
+      trapMouse={false}
     >
       <FocusTrap
         _createFocusTrap={[Function]}


### PR DESCRIPTION
Utilize the focus-trap-react library's "allowOutsideClick" option to allow clicks outside the modal when trapping focus (default behavior).

NOTE: This does not mean that clicks are allowed through the Modal's mask. That behavior is unchanged, this just allows clicks outside the whole Modal component, which includes the mask. This only really affects modals in edge case situations, i.e. non-fullscreen modals.

Additionally, the focus-trap-react library's options are only consulted when the focus trap is constructed, so changing the value of the `trapMouse` property will have no effect.

#### Changelog

**New**

- add `trapMouse` prop on Modal, to allow consumers to opt out of the new default behavior.

**Changed**

- add `allowOutsideClick` to `focusTrapOptions` on the Modal's FocusTrap.