### PR TITLE
fix(tour-tooltip): update default "close" text

### DIFF
--- a/packages/react/src/components/TourTooltip/TourTooltip.js
+++ b/packages/react/src/components/TourTooltip/TourTooltip.js
@@ -187,7 +187,7 @@ TourTooltip.propTypes = {
 TourTooltip.defaultProps = {
   nextLabel: 'Next',
   prevLabel: 'Previous',
-  closeLabel: 'Skip',
+  closeLabel: 'Skip Tour',
   checkboxLabel: "Don't show tour again.",
   hideNext: false,
   hidePrev: false,


### PR DESCRIPTION
Update the TourTooltip default close button text.

#### Changelog

**Changed**

- "Skip" is now "Skip Tour" by default.
