### PR TITLE
fix: update accordion padding-right to be consistent

### DIFF
--- a/packages/components/src/components/accordion/_accordion.scss
+++ b/packages/components/src/components/accordion/_accordion.scss
@@ -98,7 +98,7 @@
     // Transition property for when the accordion closes
     transition: padding motion(standard, productive) $duration--fast-02;
     padding-left: $carbon--spacing-05;
-    padding-right: 25%;
+    padding-right: $carbon--spacing-05;
 
     @include carbon--breakpoint-down('md') {
       padding-right: $carbon--spacing-09;


### PR DESCRIPTION
Remove the 25% padding on the right of the accordion content to be consistent with other components (button, modal, etc).

#### Changelog

**Changed**

- Changed accordion padding-right to be the same as left/top/bottom.


#### Testing / Reviewing

storybook/accordion
