### PR TITLE
fix(modal): enforcing right padding of 3rem

### DIFF
--- a/packages/components/src/components/modal/_modal.scss
+++ b/packages/components/src/components/modal/_modal.scss
@@ -91,7 +91,7 @@
       .#{$prefix}--modal-header,
       .#{$prefix}--modal-content,
       .#{$prefix}--modal-content__regular-content {
-        padding-right: 20%;
+        padding-right: $spacing-09;
       }
     }
 
@@ -108,20 +108,20 @@
   .#{$prefix}--modal-header,
   .#{$prefix}--modal-content {
     padding-left: 1rem;
-    padding-right: 3rem;
+    padding-right: $spacing-09;
   }
 
   .#{$prefix}--modal-header,
   .#{$prefix}--modal-content,
   .#{$prefix}--modal-content__regular-content {
-    padding-right: $carbon--spacing-05;
+    padding-right: $spacing-09;
   }
 
   .#{$prefix}--modal-content--with-form {
-    padding-right: $carbon--spacing-05;
+    padding-right: $spacing-09;
 
     @include carbon--breakpoint(md) {
-      padding-right: $carbon--spacing-05; // Override for `.#{$prefix}--modal-content`
+      padding-right: $spacing-09; // Override for `.#{$prefix}--modal-content`
     }
   }
 
@@ -130,7 +130,7 @@
     .#{$prefix}--modal-content,
     .#{$prefix}--modal-content__regular-content,
     .#{$prefix}--modal-content--with-form {
-      padding-right: $carbon--spacing-05;
+      padding-right: $spacing-09;
     }
 
     @include carbon--breakpoint(md) {
@@ -152,7 +152,7 @@
     .#{$prefix}--modal-content,
     .#{$prefix}--modal-content__regular-content,
     .#{$prefix}--modal-content--with-form {
-      padding-right: $carbon--spacing-05;
+      padding-right: $spacing-09;
     }
 
     @include carbon--breakpoint(md) {
@@ -170,11 +170,11 @@
       .#{$prefix}--modal-header,
       .#{$prefix}--modal-content,
       .#{$prefix}--modal-content__regular-content {
-        padding-right: 20%;
+        padding-right: $spacing-09;
       }
 
       .#{$prefix}--modal-content--with-form {
-        padding-right: $carbon--spacing-05; // Override for `.#{$prefix}--modal-content`
+        padding-right: $spacing-09; // Override for `.#{$prefix}--modal-content`
       }
     }
   }


### PR DESCRIPTION
Recent changes caused modal padding-right to regress. These changes ensure 3rems of right padding is applied regardless of viewport size

#### Changelog

**Changed**

- padding-right -> 3rem

#### Testing / Reviewing

Can be tested through storybook
