### PR TITLE
feat: tentative structure and basic HTML element wrappers for help panel

### DIFF
--- a/packages/components/src/components/ui-shell/header-widgets/_help.scss
+++ b/packages/components/src/components/ui-shell/header-widgets/_help.scss
@@ -1,0 +1,52 @@
+@import '../../globals/scss/css--helpers';
+@import '../../globals/scss/helper-mixins';
+@import '../../globals/scss/typography';
+@import '../../globals/scss/layout';
+@import '../../globals/scss/vars';
+@import 'functions';
+@import 'theme';
+
+//----------------------------------------------------------------------------
+// Header Panel > Help Panel
+//----------------------------------------------------------------------------.
+.#{$prefix}--header-panel__help--container {
+  height: 100%;
+  // padding: 1rem;
+  color: $shell-panel-text-01;
+}
+
+//  .#{$prefix}--header-panel__help--contextual {
+//   // overflow-y: auto;
+// }
+
+// .#{$prefix}--header-panel__help--tour {
+//   // overflow-y: auto;
+// }
+
+//----------------------------------------------------------------------------
+// Header Panel > Help > Title
+//----------------------------------------------------------------------------.
+.#{$prefix}--header-panel__help--title {
+  margin: rem(16px) 0;
+}
+
+//----------------------------------------------------------------------------
+// Header Panel > Help > Title
+//----------------------------------------------------------------------------.
+.#{$prefix}--header-panel__help--subtitle {
+  margin: rem(16px) 0;
+}
+
+//----------------------------------------------------------------------------
+// Header Panel > Help > List
+//----------------------------------------------------------------------------.
+.#{$prefix}--header-panel__help--list {
+  margin-top: rem(16px);
+}
+
+//----------------------------------------------------------------------------
+// Header Panel > Help > List Item
+//----------------------------------------------------------------------------.
+.#{$prefix}--header-panel__help--list-item {
+  color: $shell-panel-text-01;
+}

--- a/packages/react/src/components/UIShell/HeaderWidgets/Help/ContextualHelp.js
+++ b/packages/react/src/components/UIShell/HeaderWidgets/Help/ContextualHelp.js
@@ -1,0 +1,37 @@
+import { settings } from '@rocketsoftware/carbon-components';
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const { prefix } = settings;
+
+const ContextualHelp = ({ className: customClassName, children, id }) => {
+  const className = cx(
+    [`${prefix}--header-panel__help--contextual`],
+    customClassName
+  );
+  return (
+    <div id={id} className={className}>
+      {children}
+    </div>
+  );
+};
+
+ContextualHelp.propTypes = {
+  /**
+   * Provides an optional class to be applied to the containing node
+   */
+  className: PropTypes.string,
+
+  /**
+   * Specify the elements that make up the help content.
+   */
+  children: PropTypes.node.isRequired,
+
+  /**
+   * Specify an id to be attached to the container element.
+   */
+  id: PropTypes.string,
+};
+
+export default ContextualHelp;

--- a/packages/react/src/components/UIShell/HeaderWidgets/Help/HelpLink.js
+++ b/packages/react/src/components/UIShell/HeaderWidgets/Help/HelpLink.js
@@ -1,0 +1,41 @@
+import { settings } from '@rocketsoftware/carbon-components';
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+import Link, { LinkPropTypes } from '../../../Link';
+
+const { prefix } = settings;
+
+const HelpLink = ({ className: customClassName, children, ...rest }) => {
+  const className = cx(
+    `${prefix}--header-panel__help--link`,
+    // active??
+    customClassName
+  );
+  return (
+    <Link className={className} {...rest}>
+      {children}
+    </Link>
+  );
+};
+
+HelpLink.propTypes = {
+  ...LinkPropTypes,
+
+  /**
+   * Provides an optional class to be applied to the containing node
+   */
+  className: PropTypes.string,
+
+  /**
+   * Specify the text content for the link
+   */
+  children: PropTypes.string.isRequired,
+
+  /**
+   * Specify an id to be attached to the container element.
+   */
+  id: PropTypes.string,
+};
+
+export default HelpLink;

--- a/packages/react/src/components/UIShell/HeaderWidgets/Help/HelpList.js
+++ b/packages/react/src/components/UIShell/HeaderWidgets/Help/HelpList.js
@@ -1,0 +1,35 @@
+import { settings } from '@rocketsoftware/carbon-components';
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+import UnorderedList from '../../../UnorderedList';
+
+const { prefix } = settings;
+
+const HelpList = ({ className: customClassName, children, id }) => {
+  const className = cx(`${prefix}--header-panel__help--list`, customClassName);
+  return (
+    <UnorderedList id={id} className={className}>
+      {children}
+    </UnorderedList>
+  );
+};
+
+HelpList.propTypes = {
+  /**
+   * Provides an optional class to be applied to the containing node
+   */
+  className: PropTypes.string,
+
+  /**
+   * Specify the text content for the list
+   */
+  children: PropTypes.node.isRequired,
+
+  /**
+   * Specify an optional id to be attached to the container element.
+   */
+  id: PropTypes.string,
+};
+
+export default HelpList;

--- a/packages/react/src/components/UIShell/HeaderWidgets/Help/HelpListItem.js
+++ b/packages/react/src/components/UIShell/HeaderWidgets/Help/HelpListItem.js
@@ -1,0 +1,38 @@
+import { settings } from '@rocketsoftware/carbon-components';
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+import ListItem from '../../../ListItem';
+
+const { prefix } = settings;
+
+const HelpListItem = ({ className: customClassName, children, id }) => {
+  const className = cx(
+    `${prefix}--header-panel__help--list-item`,
+    customClassName
+  );
+  return (
+    <ListItem id={id} className={className}>
+      {children}
+    </ListItem>
+  );
+};
+
+HelpListItem.propTypes = {
+  /**
+   * Provides an optional class to be applied to the containing node
+   */
+  className: PropTypes.string,
+
+  /**
+   * Specify the text content for the listitem
+   */
+  children: PropTypes.node.isRequired,
+
+  /**
+   * Specify an optional id to be attached to the list item.
+   */
+  id: PropTypes.string,
+};
+
+export default HelpListItem;

--- a/packages/react/src/components/UIShell/HeaderWidgets/Help/HelpParagraph.js
+++ b/packages/react/src/components/UIShell/HeaderWidgets/Help/HelpParagraph.js
@@ -1,0 +1,37 @@
+import { settings } from '@rocketsoftware/carbon-components';
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const { prefix } = settings;
+
+const HelpParagraph = ({ className: customClassName, children, id }) => {
+  const className = cx(
+    `${prefix}--header-panel__help--paragraph`,
+    customClassName
+  );
+  return (
+    <p id={id} className={className}>
+      {children}
+    </p>
+  );
+};
+
+HelpParagraph.propTypes = {
+  /**
+   * Provides an optional class to be applied to the containing node
+   */
+  className: PropTypes.string,
+
+  /**
+   * Specify the text content for the paragraph
+   */
+  children: PropTypes.string.isRequired,
+
+  /**
+   * Specify an id to be attached to the text container element.
+   */
+  id: PropTypes.string,
+};
+
+export default HelpParagraph;

--- a/packages/react/src/components/UIShell/HeaderWidgets/Help/HelpSubtitle.js
+++ b/packages/react/src/components/UIShell/HeaderWidgets/Help/HelpSubtitle.js
@@ -1,0 +1,37 @@
+import { settings } from '@rocketsoftware/carbon-components';
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const { prefix } = settings;
+
+const HelpSubtitle = ({ className: customClassName, children, id }) => {
+  const className = cx(
+    `${prefix}--header-panel__help--subtitle`,
+    customClassName
+  );
+  return (
+    <h4 id={id} className={className}>
+      {children}
+    </h4>
+  );
+};
+
+HelpSubtitle.propTypes = {
+  /**
+   * Provides an optional class to be applied to the containing node
+   */
+  className: PropTypes.string,
+
+  /**
+   * Specify the text content for the subtitle
+   */
+  children: PropTypes.string.isRequired,
+
+  /**
+   * Specify an id to be attached to the container element.
+   */
+  id: PropTypes.string,
+};
+
+export default HelpSubtitle;

--- a/packages/react/src/components/UIShell/HeaderWidgets/Help/HelpTitle.js
+++ b/packages/react/src/components/UIShell/HeaderWidgets/Help/HelpTitle.js
@@ -1,0 +1,34 @@
+import { settings } from '@rocketsoftware/carbon-components';
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const { prefix } = settings;
+
+const HelpTitle = ({ className: customClassName, children, id }) => {
+  const className = cx(`${prefix}--header-panel__help--title`, customClassName);
+  return (
+    <h3 id={id} className={className}>
+      {children}
+    </h3>
+  );
+};
+
+HelpTitle.propTypes = {
+  /**
+   * Provides an optional class to be applied to the containing node
+   */
+  className: PropTypes.string,
+
+  /**
+   * Specify the text content for the title
+   */
+  children: PropTypes.string.isRequired,
+
+  /**
+   * Specify an id to be attached to the container element.
+   */
+  id: PropTypes.string,
+};
+
+export default HelpTitle;

--- a/packages/react/src/components/UIShell/HeaderWidgets/Help/HelpWidget.js
+++ b/packages/react/src/components/UIShell/HeaderWidgets/Help/HelpWidget.js
@@ -1,0 +1,37 @@
+import { settings } from '@rocketsoftware/carbon-components';
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const { prefix } = settings;
+
+const ContextualHelp = ({ className: customClassName, children, id }) => {
+  const className = cx(
+    [`${prefix}--header-panel__help--container`],
+    customClassName
+  );
+  return (
+    <div id={id} className={className}>
+      {children}
+    </div>
+  );
+};
+
+ContextualHelp.propTypes = {
+  /**
+   * Provides an optional class to be applied to the containing node
+   */
+  className: PropTypes.string,
+
+  /**
+   * Specify the elements that make up the help content.
+   */
+  children: PropTypes.node.isRequired,
+
+  /**
+   * Specify an id to be attached to the container element.
+   */
+  id: PropTypes.string,
+};
+
+export default ContextualHelp;

--- a/packages/react/src/components/UIShell/HeaderWidgets/Help/TourHelp.js
+++ b/packages/react/src/components/UIShell/HeaderWidgets/Help/TourHelp.js
@@ -1,0 +1,37 @@
+import { settings } from '@rocketsoftware/carbon-components';
+import cx from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const { prefix } = settings;
+
+const TourHelp = ({ className: customClassName, children, id }) => {
+  const className = cx(
+    [`${prefix}--header-panel__help--tour`],
+    customClassName
+  );
+  return (
+    <div id={id} className={className}>
+      {children}
+    </div>
+  );
+};
+
+TourHelp.propTypes = {
+  /**
+   * Provides an optional class to be applied to the containing node
+   */
+  className: PropTypes.string,
+
+  /**
+   * Specify the elements that make up the help content.
+   */
+  children: PropTypes.node.isRequired,
+
+  /**
+   * Specify an id to be attached to the container element.
+   */
+  id: PropTypes.string,
+};
+
+export default TourHelp;

--- a/packages/react/src/components/UIShell/HeaderWidgets/Help/index.js
+++ b/packages/react/src/components/UIShell/HeaderWidgets/Help/index.js
@@ -1,0 +1,9 @@
+export ContextualHelp from './ContextualHelp';
+
+export HelpLink from './HelpLink';
+export HelpList from './HelpList';
+export HelpListItem from './HelpListItem';
+export HelpParagraph from './HelpParagraph';
+export HelpTitle from './HelpTitle';
+export HelpSubtitle from './HelpSubtitle';
+export HelpWidget from './HelpWidget';

--- a/packages/react/src/components/UIShell/HeaderWidgets/index.js
+++ b/packages/react/src/components/UIShell/HeaderWidgets/index.js
@@ -1,0 +1,1 @@
+export * from './Help';


### PR DESCRIPTION
These are proposed, unfinished changes to the side panel to make it usable for contextual help. They won't break anything, but they won't do much, either.

My intention was for the help panel to accept different "widgets" that would be rendered inside of it. Contextual help, notifications, user preferences, etc. could all be their own widgets build to work in the side panel.
The idea for help was that the HelpWidget would consist of two different widgets - the ContextualHelp widget and the TourHelp widget - separated into tabs (or content switcher panes).

ContextualHelp is really just formatted text help. The individual elements are currently unstyled, but they are essentially wrappers for common HTML elements that we might want to include in the contextual help. It seemed to me that having simple, predefined wrapped elements would be better (if less general) than allowing _any_ elements as children of the help panel, since we can constrain and define styling/guidelines for these elements so long as we know them beforehand. 

The TourHelp widget was meant to be a central hub for displaying all tours in an application. It could have a list of available tours, each with a toggle and a "launch" button that would kick off a tour instead of just enabling it. 

Just wanted to explain some of the files and reasoning in this PR. Unfortunately, most of the interesting functionality (styling, content switching, and tour lists) has not been developed beyond the initial design, but if the contextual help approach seems reasonable then hopefully this foundational work is useful.