### PR TITLE
fix(side-nav): updated color scheme

### DIFF
--- a/packages/components/src/components/ui-shell/_side-nav.scss
+++ b/packages/components/src/components/ui-shell/_side-nav.scss
@@ -285,7 +285,8 @@
   }
 
   .#{$prefix}--side-nav__toggle:focus {
-    @include focus-outline('outline');
+    outline: 2px solid $inverse-focus-ui;
+    outline-offset: -2px;
   }
 
   .#{$prefix}--side-nav__toggle {

--- a/packages/components/src/components/ui-shell/_side-nav.scss
+++ b/packages/components/src/components/ui-shell/_side-nav.scss
@@ -75,8 +75,8 @@
     left: 0;
     width: mini-units(6);
     max-width: mini-units(32);
-    color: $shell-side-nav-text-01;
-    background-color: $shell-side-nav-bg-01;
+    color: $text-04;
+    background-color: $gray-100;
     will-change: width;
     // TODO: sync with motion work
     transition: width 0.11s cubic-bezier(0.2, 0, 1, 0.9);
@@ -273,7 +273,7 @@
   .#{$prefix}--side-nav__footer {
     flex: 0 0 rem(48px);
     width: 100%;
-    background-color: $shell-side-nav-bg-01;
+    background-color: $gray-100;
   }
 
   .#{$prefix}--side-nav__toggle {
@@ -338,8 +338,12 @@
   .#{$prefix}--side-nav
     .#{$prefix}--header__menu-title[role='menuitem'][aria-expanded='true']:hover {
     // TODO: sync color
-    background-color: $shell-side-nav-bg-04;
-    color: $ibm-color__gray-100;
+    background-color: $gray-90;
+  }
+
+  .#{$prefix}--side-nav__item--active
+    > .#{$prefix}--side-nav__link--current:hover {
+    background-color: $gray-90;
   }
 
   .#{$prefix}--side-nav__item:not(.#{$prefix}--side-nav__item--active)
@@ -349,7 +353,7 @@
     .#{$prefix}--side-nav__menu-item
     > .#{$prefix}--side-nav__link:hover
     > span {
-    color: $ibm-color__gray-100;
+    color: $text-04;
   }
 
   .#{$prefix}--side-nav__item--large {
@@ -366,7 +370,7 @@
     padding: 0 mini-units(2);
     display: flex;
     align-items: center;
-    color: $shell-side-nav-text-01;
+    color: $text-04;
     height: mini-units(4);
     user-select: none;
     transition: color $duration--fast-02, background-color $duration--fast-02,
@@ -374,12 +378,13 @@
   }
 
   .#{$prefix}--side-nav__submenu:hover {
-    background-color: $shell-side-nav-bg-04;
-    color: $ibm-color__gray-100;
+    background-color: $gray-90;
+    color: $text-04;
   }
 
   .#{$prefix}--side-nav__submenu:focus {
-    @include focus-outline('outline');
+    outline: 2px solid $inverse-focus-ui;
+    outline-offset: -2px;
   }
 
   .#{$prefix}--side-nav__submenu-title {
@@ -412,14 +417,14 @@
   }
 
   .#{$prefix}--side-nav__item--active .#{$prefix}--side-nav__submenu:hover {
-    background-color: $shell-side-nav-bg-04;
-    color: $ibm-color__gray-100;
+    background-color: $gray-90;
+    color: $text-04;
   }
 
   .#{$prefix}--side-nav__item--active
     .#{$prefix}--side-nav__submenu[aria-expanded='false'] {
-    background-color: $shell-side-nav-bg-04;
-    color: $ibm-color__gray-100;
+    background-color: $gray-70;
+    color: $text-04;
     position: relative;
     &::before {
       content: '';
@@ -432,9 +437,19 @@
     }
   }
 
+  .#{$prefix}--side-nav__item--active .#{$prefix}--side-nav__submenu:hover {
+    background-color: $gray-90;
+  }
+
+  .#{$prefix}--side-nav__menu[role='menu']
+    a.#{$prefix}--side-nav__link[role='menuitem']:not(.#{$prefix}--side-nav__link--current):not([aria-current='page']):hover {
+    background-color: $gray-90;
+    color: $text-04;
+  }
+
   .#{$prefix}--side-nav__item--active .#{$prefix}--side-nav__submenu-title {
     font-weight: 600;
-    color: $ibm-color__gray-100;
+    color: $text-04;
   }
 
   .#{$prefix}--side-nav__menu[role='menu'] {
@@ -466,16 +481,16 @@
   .#{$prefix}--side-nav__menu[role='menu']
     a.#{$prefix}--side-nav__link[aria-current='page'],
   a.#{$prefix}--side-nav__link--current {
-    background-color: $ibm-color__gray-20;
+    background-color: $gray-70;
 
     > span {
-      color: $ibm-color__gray-100;
+      color: $text-04;
       font-weight: 600;
     }
   }
 
   a.#{$prefix}--side-nav__link--current > span.#{$prefix}--side-nav__link-text {
-    color: $ibm-color__gray-100;
+    color: $text-04;
     font-weight: 600;
   }
   //----------------------------------------------------------------------------
@@ -509,7 +524,7 @@
     a.#{$prefix}--header__menu-item[role='menuitem']
     .#{$prefix}--text-truncate-end {
     @include text-overflow();
-    color: $shell-side-nav-text-01;
+    color: $text-04;
     font-size: rem(14px);
     letter-spacing: 0.1px;
     line-height: rem(20px);
@@ -518,7 +533,8 @@
 
   a.#{$prefix}--side-nav__link:focus,
   .#{$prefix}--side-nav a.#{$prefix}--header__menu-item[role='menuitem']:focus {
-    @include focus-outline('outline');
+    outline: 2px solid $inverse-focus-ui;
+    outline-offset: -2px;
   }
 
   a.#{$prefix}--side-nav__link[aria-current='page'],
@@ -535,6 +551,11 @@
     left: 0;
     width: 4px;
     background-color: $shell-side-nav-accent-01;
+  }
+
+  .#{$prefix}--side-nav__menu[role='menu']
+    a.#{$prefix}--side-nav__link--current:hover {
+    background-color: $gray-80;
   }
 
   //----------------------------------------------------------------------------
@@ -554,7 +575,7 @@
   }
 
   .#{$prefix}--side-nav__icon > svg {
-    fill: $shell-side-nav-icon-01;
+    fill: $icon-03;
     width: mini-units(2);
     height: mini-units(2);
   }
@@ -621,7 +642,7 @@
 
   //header menu items overrides
   .#{$prefix}--side-nav a.#{$prefix}--header__menu-item[role='menuitem'] {
-    color: $shell-side-nav-text-01;
+    color: $text-04;
     white-space: nowrap;
     justify-content: space-between;
 
@@ -650,8 +671,8 @@
     }
 
     & a.#{$prefix}--header__menu-item[role='menuitem']:hover {
-      background-color: $shell-side-nav-bg-04;
-      color: $ibm-color__gray-100;
+      background-color: $gray-90;
+      color: $text-04;
     }
   }
 

--- a/packages/react/src/components/UIShell/UIShell-story.js
+++ b/packages/react/src/components/UIShell/UIShell-story.js
@@ -597,11 +597,14 @@ storiesOf('UI Shell', module)
                 L0 menu item
               </SideNavMenuItem>
             </SideNavMenu>
-            <SideNavMenu title="L0 menu" isActive={true}>
+            <SideNavMenu title="L0 menu" isActive>
               <SideNavMenuItem href="javascript:void(0)">
                 L0 menu item
               </SideNavMenuItem>
-              <SideNavMenuItem aria-current="page" href="javascript:void(0)">
+              <SideNavMenuItem
+                aria-current="page"
+                isActive
+                href="javascript:void(0)">
                 L0 menu item
               </SideNavMenuItem>
               <SideNavMenuItem href="javascript:void(0)">
@@ -642,12 +645,12 @@ storiesOf('UI Shell', module)
               <SideNavMenuItem href="javascript:void(0)">Link</SideNavMenuItem>
               <SideNavMenuItem href="javascript:void(0)">Link</SideNavMenuItem>
             </SideNavMenu>
-            <SideNavMenu
-              renderIcon={Fade16}
-              title="Category title"
-              isActive={true}>
+            <SideNavMenu renderIcon={Fade16} title="Category title" isActive>
               <SideNavMenuItem href="javascript:void(0)">Link</SideNavMenuItem>
-              <SideNavMenuItem aria-current="page" href="javascript:void(0)">
+              <SideNavMenuItem
+                aria-current="page"
+                isActive
+                href="javascript:void(0)">
                 Link
               </SideNavMenuItem>
               <SideNavMenuItem href="javascript:void(0)">Link</SideNavMenuItem>
@@ -712,7 +715,10 @@ storiesOf('UI Shell', module)
           <SideNavItems>
             <SideNavMenu renderIcon={Fade16} title="Category title">
               <SideNavMenuItem href="javascript:void(0)">Link</SideNavMenuItem>
-              <SideNavMenuItem aria-current="page" href="javascript:void(0)">
+              <SideNavMenuItem
+                aria-current="page"
+                isActive
+                href="javascript:void(0)">
                 Link
               </SideNavMenuItem>
               <SideNavMenuItem href="javascript:void(0)">Link</SideNavMenuItem>
@@ -793,6 +799,7 @@ storiesOf('UI Shell', module)
                       Link
                     </SideNavMenuItem>
                     <SideNavMenuItem
+                      isActive
                       aria-current="page"
                       href="javascript:void(0)">
                       Link
@@ -807,6 +814,7 @@ storiesOf('UI Shell', module)
                     </SideNavMenuItem>
                     <SideNavMenuItem
                       aria-current="page"
+                      isActive
                       href="javascript:void(0)">
                       Link
                     </SideNavMenuItem>
@@ -819,6 +827,7 @@ storiesOf('UI Shell', module)
                       Link
                     </SideNavMenuItem>
                     <SideNavMenuItem
+                      isActive
                       aria-current="page"
                       href="javascript:void(0)">
                       Link
@@ -924,6 +933,7 @@ storiesOf('UI Shell', module)
                       Link
                     </SideNavMenuItem>
                     <SideNavMenuItem
+                      isActive
                       aria-current="page"
                       href="javascript:void(0)">
                       Link


### PR DESCRIPTION
Changes side-nav color scheme to be more inline with the rest of the ui-shell components

#### Changelog

**Changed**

- Various changes to side-nav.scss for color and background color
- Made minor edits to stories so that isActive is properly used instead of just aria-current

#### Testing / Reviewing

See storybook
