### PR TITLE
fix(listbox): remove unnecessary role

### DIFF
--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
@@ -78,7 +78,6 @@ exports[`Dropdown should render 1`] = `
           id="dropdown-1"
           onClick={[Function]}
           onKeyDown={[Function]}
-          role="listbox"
           tabIndex="-1"
         >
           <ListBoxField
@@ -253,7 +252,6 @@ exports[`Dropdown should render custom item components 1`] = `
           id="dropdown-5"
           onClick={[Function]}
           onKeyDown={[Function]}
-          role="listbox"
           tabIndex="-1"
         >
           <ListBoxField
@@ -587,7 +585,6 @@ exports[`Dropdown should render with strings as items 1`] = `
           id="dropdown-4"
           onClick={[Function]}
           onKeyDown={[Function]}
-          role="listbox"
           tabIndex="-1"
         >
           <ListBoxField

--- a/packages/react/src/components/ListBox/ListBox.js
+++ b/packages/react/src/components/ListBox/ListBox.js
@@ -54,7 +54,6 @@ const ListBox = ({
     <>
       <div
         {...rest}
-        role="listbox"
         tabIndex="-1"
         className={className}
         ref={innerRef}

--- a/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
+++ b/packages/react/src/components/ListBox/__tests__/__snapshots__/ListBox-test.js.snap
@@ -12,7 +12,6 @@ exports[`ListBox should render 1`] = `
           <div
             class="bx--list-box__container bx--list-box"
             id="test-listbox"
-            role="listbox"
             tabindex="-1"
           >
             <div
@@ -39,7 +38,6 @@ exports[`ListBox should render 1`] = `
     id="test-listbox"
     onClick={[Function]}
     onKeyDown={[Function]}
-    role="listbox"
     tabIndex="-1"
   >
     <ListBoxField

--- a/packages/react/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
+++ b/packages/react/src/components/MultiSelect/__tests__/__snapshots__/FilterableMultiSelect-test.js.snap
@@ -90,7 +90,6 @@ exports[`MultiSelect.Filterable should render 1`] = `
             className="bx--multi-select bx--combo-box bx--multi-select--filterable bx--list-box"
             onClick={[Function]}
             onKeyDown={[Function]}
-            role="listbox"
             tabIndex="-1"
           >
             <ListBoxField

--- a/packages/react/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
+++ b/packages/react/src/components/MultiSelect/__tests__/__snapshots__/MultiSelect-test.js.snap
@@ -90,7 +90,6 @@ exports[`MultiSelect should render 1`] = `
             id="test-multiselect"
             onClick={[Function]}
             onKeyDown={[Function]}
-            role="listbox"
             tabIndex="-1"
           >
             <ListBoxField


### PR DESCRIPTION
Removes unnecessary role from ListBox which was causing accessibility checks to fail 

#### Changelog

**Changed**

- Updated test snapshot for ListBox

**Removed**

- `role="listbox"` from ListBox component

#### Testing / Reviewing

via storybook
