### PR TITLE
feat(overflow-menu): primaryFocus on first child by default

### DIFF
--- a/packages/react/src/components/OverflowMenu/OverflowMenu-story.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu-story.js
@@ -46,11 +46,7 @@ const props = {
 const OverflowMenuExample = ({ overflowMenuProps, overflowMenuItemProps }) => (
   <>
     <OverflowMenu {...overflowMenuProps}>
-      <OverflowMenuItem
-        {...overflowMenuItemProps}
-        itemText="Option 1"
-        primaryFocus
-      />
+      <OverflowMenuItem {...overflowMenuItemProps} itemText="Option 1" />
       <OverflowMenuItem
         {...overflowMenuItemProps}
         itemText="Option 2 is an example of a really long string and how we recommend handling this"

--- a/packages/react/src/components/OverflowMenu/OverflowMenu.js
+++ b/packages/react/src/components/OverflowMenu/OverflowMenu.js
@@ -210,6 +210,13 @@ class OverflowMenu extends Component {
     getViewport: PropTypes.func,
 
     /**
+     * Optionally flag whether primaryFocus should be set to true on the first child in the body.
+     * `true` by default. If set to false `primaryFocus` needs to be added to one of the
+     *  OverflowItems to maintain accesability.
+     */
+    openFocus: PropTypes.bool,
+
+    /**
      * `true` to use the light version. For use on $ui-01 backgrounds only.
      * Don't use this to make OverflowMenu background color same as container background color.
      */
@@ -230,6 +237,7 @@ class OverflowMenu extends Component {
     tabIndex: 0,
     menuOffset: getMenuOffset,
     menuOffsetFlip: getMenuOffset,
+    openFocus: true,
     light: false,
   };
 
@@ -475,6 +483,7 @@ class OverflowMenu extends Component {
       menuOptionsClass,
       getViewport,
       light,
+      openFocus,
       ...other
     } = this.props;
 
@@ -508,6 +517,7 @@ class OverflowMenu extends Component {
       (child, index) =>
         React.cloneElement(child, {
           closeMenu: this.closeMenu,
+          primaryFocus: openFocus === true && index === 0,
           handleOverflowMenuItemFocus: this.handleOverflowMenuItemFocus,
           ref: e => {
             this[`overflowMenuItem${index}`] = e;


### PR DESCRIPTION
The PR adds the ability for the OverflowMenu component to add primaryFocus onto the first child by default rather than putting the onus on the developer to do so.

#### Changelog

**New**
- added conditional `primaryFocus` prop to React.cloneElement that evaluates to true when both `openFocus === true` and `index ===0`
- `openFocus` prop to enable/disable conditional prop

**Changed**

- Adjusted stories to reflect change

#### Testing / Reviewing

via storybook
