### PR TITLE
chore(project): fix export statements

### DIFF
--- a/packages/react/src/__tests__/index-test.js
+++ b/packages/react/src/__tests__/index-test.js
@@ -22,6 +22,7 @@ describe('Carbon Components React', () => {
         "BreadcrumbItem",
         "BreadcrumbSkeleton",
         "Button",
+        "ButtonGroup",
         "ButtonSkeleton",
         "Card",
         "CardActionItem",
@@ -58,6 +59,9 @@ describe('Carbon Components React', () => {
         "FileUploaderItem",
         "FileUploaderSkeleton",
         "Filename",
+        "FlatProgressIndicator",
+        "FlatProgressIndicatorSkeleton",
+        "FlatProgressStep",
         "Form",
         "FormGroup",
         "FormItem",
@@ -131,6 +135,7 @@ describe('Carbon Components React', () => {
         "SkipToContent",
         "Slider",
         "SliderSkeleton",
+        "SplitButton",
         "StructuredListBody",
         "StructuredListCell",
         "StructuredListHead",
@@ -195,11 +200,6 @@ describe('Carbon Components React', () => {
         "Tour",
         "TourTooltip",
         "UnorderedList",
-        "SplitButton",
-        "ButtonGroup",
-        "FlatProgressIndicator",
-        "FlatProgressStep",
-        "FlatProgressIndicatorSkeleton",
       ]
     `);
   });

--- a/packages/react/src/__tests__/index-test.js
+++ b/packages/react/src/__tests__/index-test.js
@@ -195,6 +195,9 @@ describe('Carbon Components React', () => {
         "Tour",
         "TourTooltip",
         "UnorderedList",
+        "SplitButton",
+        "ButtonGroup",
+        "FlatProgressIndicator",
       ]
     `);
   });

--- a/packages/react/src/__tests__/index-test.js
+++ b/packages/react/src/__tests__/index-test.js
@@ -198,6 +198,8 @@ describe('Carbon Components React', () => {
         "SplitButton",
         "ButtonGroup",
         "FlatProgressIndicator",
+        "FlatProgressStep",
+        "FlatProgressIndicatorSkeleton",
       ]
     `);
   });

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -174,4 +174,8 @@ export TourTooltip from './components/TourTooltip';
 export * from './components/UIShell';
 export SplitButton from './components/SplitButton';
 export ButtonGroup from './components/ButtonGroup';
-export FlatProgressIndicator from './components/FlatProgressIndicator';
+export {
+  FlatProgressIndicator,
+  FlatProgressStep,
+} from './components/FlatProgressIndicator';
+export FlatProgressIndicatorSkeleton from './components/FlatProgressIndicator/FlatProgressIndicator.Skeleton';

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -172,3 +172,6 @@ export DatePickerSkeleton from './components/DatePicker/DatePicker.Skeleton';
 export Tour from './components/Tour';
 export TourTooltip from './components/TourTooltip';
 export * from './components/UIShell';
+export SplitButton from './components/SplitButton';
+export ButtonGroup from './components/ButtonGroup';
+export FlatProgressIndicator from './components/FlatProgressIndicator';


### PR DESCRIPTION
Fixes issue where some of the pattern components were missing export statements in the main index file preventing named imports from working without providing and explicit path to the folder the component is stored in.

#### Changelog

**New**

- Adds missing export statements

