### PR TITLE
fix(split-button): flex container to inline-flex

### DIFF
--- a/packages/components/src/components/split-button/_split-button.scss
+++ b/packages/components/src/components/split-button/_split-button.scss
@@ -14,7 +14,7 @@
 @import '../overflow-menu/overflow-menu';
 
 .#{$prefix}--btn--split--container {
-  display: flex;
+  display: inline-flex;
 
   .#{$prefix}--btn--split--overflow {
     width: 3rem;


### PR DESCRIPTION
Changes container display style to inline flex as flex was taking up the full with of it's container rather than only wrapping just the button components.

#### Changelog

**Changed**

- display: flex -> inline-flex

#### Testing / Reviewing

storybook
