### PR TITLE
fix(button-group): flex container to inline-flex

### DIFF
--- a/packages/components/src/components/button-group/_button-group.scss
+++ b/packages/components/src/components/button-group/_button-group.scss
@@ -11,7 +11,7 @@
 @import 'mixins';
 
 .#{$prefix}--btn-group {
-  display: flex;
+  display: inline-flex;
   .#{$prefix}--overflow-menu {
     height: unset;
     width: unset;

--- a/packages/react/src/components/ButtonGroup/ButtonGroup-story.js
+++ b/packages/react/src/components/ButtonGroup/ButtonGroup-story.js
@@ -36,7 +36,7 @@ storiesOf('Pattern|ButtonGroup', module)
       const regularProps = props.regular();
       return (
         <ButtonGroup {...regularProps}>
-          <OverflowMenuItem itemText={'Item 1'} />
+          <OverflowMenuItem primaryFocus itemText={'Item 1'} />
           <OverflowMenuItem itemText={'Item 2'} />
           <OverflowMenuItem itemText={'Item 3'} />
         </ButtonGroup>


### PR DESCRIPTION
Changes container display style to inline flex as flex was taking up the full with of it's container rather than only wrapping just the button components.

#### Changelog

**Changed**

- display: flex -> inline-flex

#### Testing / Reviewing

storybook
