### PR TITLE
fix(ComboBox): changed interaction pattern with search field

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox-story.js
+++ b/packages/react/src/components/ComboBox/ComboBox-story.js
@@ -116,6 +116,26 @@ storiesOf('ComboBox', module)
     }
   )
   .add(
+    'with shouldFilterItem',
+    () => (
+      <div style={{ width: 300 }}>
+        <ComboBox
+          items={items}
+          itemToString={item => (item ? item.text : '')}
+          {...props()}
+          shouldFilterItem={({ inputValue, item, itemToString }) =>
+            itemToString(item).includes(inputValue)
+          }
+        />
+      </div>
+    ),
+    {
+      info: {
+        text: `Utilizes the shouldFilterItem prop to filter out options based on input rather than just highlighting the closest match.`,
+      },
+    }
+  )
+  .add(
     'application-level control for selection',
     () => <ControlledComboBoxApp {...props()} />,
     {

--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -262,7 +262,7 @@ export default class ComboBox extends React.Component {
       event.preventDownshiftDefault = true;
       event.persist();
     }
-    if (event.target === this.textInput.current && !isOpen) {
+    if (!isOpen) {
       this.setState({ useFilter: false });
     }
   };

--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -236,7 +236,6 @@ export default class ComboBox extends React.Component {
 
   handleOnInputValueChange = inputValue => {
     const { onInputChange } = this.props;
-    console.log('HANDLE ON INPUT VALUE CHANGE');
     this.setState({ useFilter: true });
     this.setState(
       () => ({
@@ -260,7 +259,6 @@ export default class ComboBox extends React.Component {
 
   onToggleClick = isOpen => event => {
     if (event.target === this.textInput.current && isOpen) {
-      console.log('IN FIRST IF STATEMENT');
       event.preventDownshiftDefault = true;
       event.persist();
     }

--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -215,6 +215,7 @@ export default class ComboBox extends React.Component {
 
     this.state = {
       inputValue: getInputValue(props, {}),
+      useFilter: false,
     };
   }
 
@@ -235,7 +236,8 @@ export default class ComboBox extends React.Component {
 
   handleOnInputValueChange = inputValue => {
     const { onInputChange } = this.props;
-
+    console.log('HANDLE ON INPUT VALUE CHANGE');
+    this.setState({ useFilter: true });
     this.setState(
       () => ({
         // Default to empty string if we have a false-y `inputValue`
@@ -258,8 +260,12 @@ export default class ComboBox extends React.Component {
 
   onToggleClick = isOpen => event => {
     if (event.target === this.textInput.current && isOpen) {
+      console.log('IN FIRST IF STATEMENT');
       event.preventDownshiftDefault = true;
       event.persist();
+    }
+    if (event.target === this.textInput.current && !isOpen) {
+      this.setState({ useFilter: false });
     }
   };
 
@@ -290,6 +296,8 @@ export default class ComboBox extends React.Component {
       direction,
       ...rest
     } = this.props;
+
+    const { useFilter } = this.state;
     const className = cx(`${prefix}--combo-box`, containerClassName, {
       [`${prefix}--list-box--up`]: direction === 'top',
     });
@@ -382,6 +390,7 @@ export default class ComboBox extends React.Component {
                     event.stopPropagation();
 
                     if (match(event, keys.Enter)) {
+                      this.setState({ useFilter: true });
                       toggleMenu();
                     }
                   },
@@ -405,37 +414,39 @@ export default class ComboBox extends React.Component {
               />
             </ListBox.Field>
             <ListBox.Menu aria-label={ariaLabel} id={id}>
-              {this.filterItems(items, itemToString, inputValue).map(
-                (item, index) => {
-                  const itemProps = getItemProps({
-                    item,
-                    index,
-                  });
-                  return (
-                    <ListBox.MenuItem
-                      key={itemProps.id}
-                      isActive={selectedItem === item}
-                      isHighlighted={
-                        highlightedIndex === index ||
-                        (selectedItem && selectedItem.id === item.id) ||
-                        false
-                      }
-                      title={itemToElement ? item.text : itemToString(item)}
-                      {...itemProps}>
-                      {itemToElement ? (
-                        <ItemToElement key={itemProps.id} {...item} />
-                      ) : (
-                        itemToString(item)
-                      )}
-                      {selectedItem === item && (
-                        <Checkmark16
-                          className={`${prefix}--list-box__menu-item__selected-icon`}
-                        />
-                      )}
-                    </ListBox.MenuItem>
-                  );
-                }
-              )}
+              {this.filterItems(
+                items,
+                itemToString,
+                useFilter ? inputValue : ''
+              ).map((item, index) => {
+                const itemProps = getItemProps({
+                  item,
+                  index,
+                });
+                return (
+                  <ListBox.MenuItem
+                    key={itemProps.id}
+                    isActive={selectedItem === item}
+                    isHighlighted={
+                      highlightedIndex === index ||
+                      (selectedItem && selectedItem.id === item.id) ||
+                      false
+                    }
+                    title={itemToElement ? item.text : itemToString(item)}
+                    {...itemProps}>
+                    {itemToElement ? (
+                      <ItemToElement key={itemProps.id} {...item} />
+                    ) : (
+                      itemToString(item)
+                    )}
+                    {selectedItem === item && (
+                      <Checkmark16
+                        className={`${prefix}--list-box__menu-item__selected-icon`}
+                      />
+                    )}
+                  </ListBox.MenuItem>
+                );
+              })}
             </ListBox.Menu>
           </ListBox>
         )}


### PR DESCRIPTION
Changes interaction when first clicking on search field to not filter out items when `shouldFilterItem` is used.

#### Changelog

**New**

- Story showing an implementation of `shouldFilterItem`
- Added `useFilter` state variable

**Changed**

- Modified event handlers to properly handle `useFilter`

#### Testing / Reviewing

See new story
