### PR TITLE
Fix styling for pagination

### DIFF
--- a/packages/react/src/components/Pagination/Pagination.js
+++ b/packages/react/src/components/Pagination/Pagination.js
@@ -270,7 +270,12 @@ export default class Pagination extends Component {
   };
 
   customStyles = {
-    valueContainer: () => ({
+    container: (base) => ({
+      ...base,
+      marginRight: '.5rem',
+    }),
+    valueContainer: (base) => ({
+      ...base,
       width: '4rem',
     }),
   };
@@ -372,6 +377,7 @@ export default class Pagination extends Component {
             styles={this.customStyles}
             isDisabled={pageInputDisabled || disabled}
             onChange={this.handlePageInputChange}
+            menuPlacement={'auto'}
           />
           <span className={`${prefix}--pagination__text`}>
             {pagesUnknown


### PR DESCRIPTION
Fix styling for pagination

Closes #

There is an issue of placement of menu that shows page numbers  if the pagination component is at the bottom.

#### Changelog

**New**

The placement of menu corrected if the pagination component is at the bottom.

**Changed**

Used menuPlacement property with value as "auto" of react-windowed-select component
