### PR TITLE
fix(tabs): selectTabAt logic changes

### DIFF
--- a/packages/react/src/components/Tabs/Tabs.js
+++ b/packages/react/src/components/Tabs/Tabs.js
@@ -284,12 +284,18 @@ export default class Tabs extends React.Component {
 
   selectTabAt = (event, { index, onSelectionChange }) => {
     this.scrollTabIntoView(event, { index });
-    if (this.state.selected !== index) {
-      this.setState({
-        selected: index,
-      });
-      if (typeof onSelectionChange === 'function') {
-        onSelectionChange(index);
+    const returnValue =
+      typeof onSelectionChange === 'function' && onSelectionChange(index);
+    if (
+      !onSelectionChange ||
+      (typeof onSelectionChange === 'function' &&
+        typeof returnValue === 'undefined') ||
+      returnValue
+    ) {
+      if (this.state.selected !== index) {
+        this.setState({
+          selected: index,
+        });
       }
     }
   };


### PR DESCRIPTION
Makes the default state change call conditional on whether the onSelectionChange prop is set.

#### Changelog

**Changed**

- selectTabAt logic changed to make the default state change call conditional on whether onSelectoinChange prop is set. onSelectionChange now expects a function to call for the state change and some return value.
#### Testing / Reviewing

See storybook preview for review
