### PR TITLE
fix(filterablemultiselect): fixed highlight issue for keyboard and mouse use

### DIFF
--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -203,9 +203,27 @@ export default class FilterableMultiSelect extends React.Component {
       topItems: [],
       inputFocused: false,
       highlightedIndex: null,
+      listBoxId: null,
     };
     this.textInput = React.createRef();
   }
+
+  onListBoxMenuRefChange = (node) => {
+    if (node) {
+      this.setState({ listBoxId: node.id });
+      document.getElementById(node.id) &&
+        document
+          .getElementById(node.id)
+          .addEventListener('mouseleave', () =>
+            this.setState({ highlightedIndex: null })
+          );
+    } else {
+      document.getElementById(this.state.listBoxId) &&
+        document
+          .getElementById(this.state.listBoxId)
+          .removeEventListener('mouseleave', () => {});
+    }
+  };
 
   handleOnChange = (changes) => {
     if (this.props.onChange) {
@@ -217,6 +235,9 @@ export default class FilterableMultiSelect extends React.Component {
     this.setState((state) => ({
       isOpen: isOpen ?? !state.isOpen,
     }));
+    if (!isOpen) {
+      this.setState({ highlightedIndex: null });
+    }
     if (this.props.onMenuChange) {
       this.props.onMenuChange(isOpen);
     }
@@ -238,6 +259,7 @@ export default class FilterableMultiSelect extends React.Component {
       case stateChangeTypes.keyDownArrowDown:
       case stateChangeTypes.keyDownArrowUp:
       case stateChangeTypes.keyDownHome:
+      case stateChangeTypes.itemMouseEnter:
       case stateChangeTypes.keyDownEnd:
         this.setState({
           highlightedIndex:
@@ -546,7 +568,9 @@ export default class FilterableMultiSelect extends React.Component {
                       />
                     </div>
                     {isOpen ? (
-                      <ListBox.Menu {...menuProps}>
+                      <ListBox.Menu
+                        {...menuProps}
+                        ref={this.onListBoxMenuRefChange}>
                         {sortItems(
                           filterItems(items, { itemToString, inputValue }),
                           {

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -210,18 +210,9 @@ export default class FilterableMultiSelect extends React.Component {
 
   onListBoxMenuRefChange = (node) => {
     if (node) {
-      this.setState({ listBoxId: node.id });
-      document.getElementById(node.id) &&
-        document
-          .getElementById(node.id)
-          .addEventListener('mouseleave', () =>
-            this.setState({ highlightedIndex: null })
-          );
-    } else {
-      document.getElementById(this.state.listBoxId) &&
-        document
-          .getElementById(this.state.listBoxId)
-          .removeEventListener('mouseleave', () => {});
+      node.addEventListener('mouseleave', () =>
+        this.setState({ highlightedIndex: null })
+      );
     }
   };
 

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -203,7 +203,6 @@ export default class FilterableMultiSelect extends React.Component {
       topItems: [],
       inputFocused: false,
       highlightedIndex: null,
-      listBoxId: null,
     };
     this.textInput = React.createRef();
   }


### PR DESCRIPTION
Closes #
this will fix below issues
1. when user try to use multiselect with keyboard then every time when dropdown opens it will reset old highlighted item
2. when we use in combination of  mouse and keyboard up/down arrow then focus will start from last highlighted item
3. when item is highlighted by use of keyboard up/down arrow and start using by mouse then keyboard highlighted item will reset

#### Changelog
1.since Downshift doesn't have mouseLeave event added function to add 'mouseLeave' event
2.no need of remove events since, with node all the associated events also gets removed
2.added ref to ListBoxMenu
**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}

check filterable multiselect with keyboard and by mouse also check with combination of both
