### PR TITLE
fix(pagination): added props to make menu placement customizable

### DIFF
--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -4402,6 +4402,7 @@ Map {
       "itemRangeText": [Function],
       "itemText": [Function],
       "itemsPerPageText": "Items per page:",
+      "menuPlacement": "auto",
       "page": 1,
       "pageNumberText": "Page Number",
       "pageRangeText": [Function],
@@ -4445,6 +4446,16 @@ Map {
       },
       "itemsPerPageText": Object {
         "type": "string",
+      },
+      "menuPlacement": Object {
+        "args": Array [
+          Array [
+            "auto",
+            "top",
+            "bottom",
+          ],
+        ],
+        "type": "oneOf",
       },
       "onChange": Object {
         "type": "func",

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -203,9 +203,27 @@ export default class FilterableMultiSelect extends React.Component {
       topItems: [],
       inputFocused: false,
       highlightedIndex: null,
+      listBoxId: null,
     };
     this.textInput = React.createRef();
   }
+
+  onListBoxMenuRefChange = (node) => {
+    if (node) {
+      this.setState({ listBoxId: node.id });
+      document.getElementById(node.id) &&
+        document
+          .getElementById(node.id)
+          .addEventListener('mouseleave', () =>
+            this.setState({ highlightedIndex: null })
+          );
+    } else {
+      document.getElementById(this.state.listBoxId) &&
+        document
+          .getElementById(this.state.listBoxId)
+          .removeEventListener('mouseleave', () => {});
+    }
+  };
 
   handleOnChange = (changes) => {
     if (this.props.onChange) {
@@ -217,6 +235,9 @@ export default class FilterableMultiSelect extends React.Component {
     this.setState((state) => ({
       isOpen: isOpen ?? !state.isOpen,
     }));
+    if (!isOpen) {
+      this.setState({ highlightedIndex: null });
+    }
     if (this.props.onMenuChange) {
       this.props.onMenuChange(isOpen);
     }
@@ -238,6 +259,7 @@ export default class FilterableMultiSelect extends React.Component {
       case stateChangeTypes.keyDownArrowDown:
       case stateChangeTypes.keyDownArrowUp:
       case stateChangeTypes.keyDownHome:
+      case stateChangeTypes.itemMouseEnter:
       case stateChangeTypes.keyDownEnd:
         this.setState({
           highlightedIndex:
@@ -546,7 +568,9 @@ export default class FilterableMultiSelect extends React.Component {
                       />
                     </div>
                     {isOpen ? (
-                      <ListBox.Menu {...menuProps}>
+                      <ListBox.Menu
+                        {...menuProps}
+                        ref={this.onListBoxMenuRefChange}>
                         {sortItems(
                           filterItems(items, { itemToString, inputValue }),
                           {

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -210,18 +210,9 @@ export default class FilterableMultiSelect extends React.Component {
 
   onListBoxMenuRefChange = (node) => {
     if (node) {
-      this.setState({ listBoxId: node.id });
-      document.getElementById(node.id) &&
-        document
-          .getElementById(node.id)
-          .addEventListener('mouseleave', () =>
-            this.setState({ highlightedIndex: null })
-          );
-    } else {
-      document.getElementById(this.state.listBoxId) &&
-        document
-          .getElementById(this.state.listBoxId)
-          .removeEventListener('mouseleave', () => {});
+      node.addEventListener('mouseleave', () =>
+        this.setState({ highlightedIndex: null })
+      );
     }
   };
 

--- a/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
+++ b/packages/react/src/components/MultiSelect/FilterableMultiSelect.js
@@ -203,7 +203,6 @@ export default class FilterableMultiSelect extends React.Component {
       topItems: [],
       inputFocused: false,
       highlightedIndex: null,
-      listBoxId: null,
     };
     this.textInput = React.createRef();
   }

--- a/packages/react/src/components/Pagination/Pagination.js
+++ b/packages/react/src/components/Pagination/Pagination.js
@@ -100,6 +100,11 @@ export default class Pagination extends Component {
     itemsPerPageText: PropTypes.string,
 
     /**
+     * The placement of dropdwon either in top or bottom direction. By default its auto.
+     */
+    menuPlacement: PropTypes.oneOf(['auto', 'top', 'bottom']),
+
+    /**
      * The callback function called when the current page changes.
      */
     onChange: PropTypes.func,
@@ -174,6 +179,7 @@ export default class Pagination extends Component {
     isLastPage: false,
     itemText: (min, max) => `${min}–${max} items`,
     pageText: (page) => `page ${page}`,
+    menuPlacement: 'auto',
   };
 
   static getDerivedStateFromProps(
@@ -301,6 +307,7 @@ export default class Pagination extends Component {
       pageInputDisabled,
       pageSizeInputDisabled,
       totalItems,
+      menuPlacement,
       onChange, // eslint-disable-line no-unused-vars
       page: pageNumber, // eslint-disable-line no-unused-vars
       ...other
@@ -379,7 +386,7 @@ export default class Pagination extends Component {
             styles={this.customStyles}
             isDisabled={pageInputDisabled || disabled}
             onChange={this.handlePageInputChange}
-            menuPlacement={'auto'}
+            menuPlacement={menuPlacement}
           />
           <span className={`${prefix}--pagination__text`}>
             {pagesUnknown


### PR DESCRIPTION
Closes #
open menu in either upward or downward direction as per requirement 

#### Changelog

**New**

added props to make menu placement customizable

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
