### PR TITLE
fix(sorting): multiselect sorting fixed

### DIFF
--- a/packages/react/src/components/MultiSelect/tools/sorting.js
+++ b/packages/react/src/components/MultiSelect/tools/sorting.js
@@ -28,8 +28,12 @@ export const defaultSortItems = (
   { selectedItems = [], itemToString, compareItems, locale = 'en' }
 ) =>
   items.sort((itemA, itemB) => {
-    const hasItemA = selectedItems.includes(itemA);
-    const hasItemB = selectedItems.includes(itemB);
+    const hasItemA = selectedItems.some(
+      (item) => JSON.stringify(item) === JSON.stringify(itemA)
+    );
+    const hasItemB = selectedItems.some(
+      (item) => JSON.stringify(item) === JSON.stringify(itemB)
+    );
 
     // Prefer whichever item is in the `selectedItems` array first
     if (hasItemA && !hasItemB) {


### PR DESCRIPTION
Closes #

The selected items do not appear as first on the filterable multiselect dropdown if the reference is different

#### Changelog

The sorting was initially done for it using includes (it works on matching the reference of the an item in the array).
Switched it to match the values