### PR TITLE
fix(accessibility): added fix on table expand row

### DIFF
--- a/packages/components/src/components/list-box/_list-box.scss
+++ b/packages/components/src/components/list-box/_list-box.scss
@@ -678,7 +678,8 @@ $list-box-menu-width: rem(300px);
 
   .#{$prefix}--list-box__menu-item--highlighted {
     border-color: transparent;
-    background-color: $layer-hover;
+    /* stylelint-disable-next-line declaration-no-important */
+    background-color: $layer-hover !important;
     color: $text-primary;
   }
 

--- a/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
+++ b/packages/react/__tests__/__snapshots__/PublicAPI-test.js.snap
@@ -2625,6 +2625,9 @@ Map {
       "ariaLabel": Object {
         "type": "string",
       },
+      "ariaLabelMenu": Object {
+        "type": "string",
+      },
       "className": Object {
         "type": "string",
       },

--- a/packages/react/src/components/DataTable/TableExpandRow.js
+++ b/packages/react/src/components/DataTable/TableExpandRow.js
@@ -34,7 +34,8 @@ const TableExpandRow = ({
     rowClassName
   );
   const previousValue = isExpanded ? 'collapsed' : undefined;
-  const expandHeaderValue = expandHeader === 'expand' ? null : expandHeader;
+  const expandHeaderValue =
+    expandHeader === 'expand' ? undefined : expandHeader;
 
   return (
     <tr {...rest} className={className} data-parent-row>

--- a/packages/react/src/components/DataTable/TableExpandRow.js
+++ b/packages/react/src/components/DataTable/TableExpandRow.js
@@ -34,13 +34,15 @@ const TableExpandRow = ({
     rowClassName
   );
   const previousValue = isExpanded ? 'collapsed' : undefined;
+  const expandHeaderValue = expandHeader === 'expand' ? null : expandHeader;
 
   return (
     <tr {...rest} className={className} data-parent-row>
       <TableCell
         className={`${prefix}--table-expand`}
         data-previous-value={previousValue}
-        headers={expandHeader}>
+        headers={expandHeaderValue}
+        scope={'row'}>
         <button
           type="button"
           className={`${prefix}--table-expand__button`}

--- a/packages/react/src/components/DataTable/__tests__/TableExpandRow-test.js
+++ b/packages/react/src/components/DataTable/__tests__/TableExpandRow-test.js
@@ -18,7 +18,6 @@ describe('DataTable.TableExpandRow', () => {
       isExpanded: false,
       onExpand: jest.fn(),
       ariaLabel: 'Aria label',
-      scope: 'row',
     };
   });
 

--- a/packages/react/src/components/DataTable/__tests__/TableExpandRow-test.js
+++ b/packages/react/src/components/DataTable/__tests__/TableExpandRow-test.js
@@ -18,6 +18,7 @@ describe('DataTable.TableExpandRow', () => {
       isExpanded: false,
       onExpand: jest.fn(),
       ariaLabel: 'Aria label',
+      scope: 'row',
     };
   });
 

--- a/packages/react/src/components/DataTable/__tests__/__snapshots__/TableExpandRow-test.js.snap
+++ b/packages/react/src/components/DataTable/__tests__/__snapshots__/TableExpandRow-test.js.snap
@@ -30,11 +30,11 @@ exports[`DataTable.TableExpandRow should render 1`] = `
             >
               <TableCell
                 className="bx--table-expand"
-                headers="expand"
+                scope="row"
               >
                 <td
                   className="bx--table-expand"
-                  headers="expand"
+                  scope="row"
                 >
                   <button
                     aria-label="Aria label"

--- a/packages/react/src/components/Dropdown/Dropdown-story.js
+++ b/packages/react/src/components/Dropdown/Dropdown-story.js
@@ -67,6 +67,10 @@ const props = () => ({
   direction: select('Dropdown direction (direction)', directions, 'bottom'),
   label: text('Label (label)', 'Dropdown menu options'),
   ariaLabel: text('Aria Label (ariaLabel)', 'Dropdown'),
+  ariaLabelMenu: text(
+    'Aria Label for Menu List (ariaLabelMenu)',
+    'Dropdown Menu'
+  ),
   disabled: boolean('Disabled (disabled)', false),
   light: boolean('Light variant (light)', false),
   titleText: text('Title (titleText)', 'Dropdown label'),

--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -141,7 +141,9 @@ const Dropdown = React.forwardRef(function Dropdown(
 
   const menuItemOptionRefs = useRef(items.map((_) => React.createRef()));
   const ariaLabelForMenu =
-    ariaLabelMenu || ariaLabel ? `${ariaLabel}__menu` : undefined;
+    ariaLabelMenu || ariaLabel
+      ? `${ariaLabel}__menu`
+      : 'Dropdown menu list box';
 
   return (
     <div className={wrapperClasses} {...other}>

--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -140,11 +140,8 @@ const Dropdown = React.forwardRef(function Dropdown(
   }
 
   const menuItemOptionRefs = useRef(items.map((_) => React.createRef()));
-  const ariaLabelForMenu = ariaLabelMenu
-    ? ariaLabelMenu
-    : ariaLabel
-    ? `${ariaLabel}__menu`
-    : undefined;
+  const ariaLabelForMenu =
+    ariaLabelMenu || ariaLabel ? `${ariaLabel}__menu` : undefined;
 
   return (
     <div className={wrapperClasses} {...other}>

--- a/packages/react/src/components/Dropdown/Dropdown.js
+++ b/packages/react/src/components/Dropdown/Dropdown.js
@@ -38,6 +38,7 @@ const Dropdown = React.forwardRef(function Dropdown(
     items,
     label,
     ariaLabel,
+    ariaLabelMenu,
     itemToString,
     itemToElement,
     type,
@@ -139,6 +140,11 @@ const Dropdown = React.forwardRef(function Dropdown(
   }
 
   const menuItemOptionRefs = useRef(items.map((_) => React.createRef()));
+  const ariaLabelForMenu = ariaLabelMenu
+    ? ariaLabelMenu
+    : ariaLabel
+    ? `${ariaLabel}__menu`
+    : undefined;
 
   return (
     <div className={wrapperClasses} {...other}>
@@ -178,7 +184,7 @@ const Dropdown = React.forwardRef(function Dropdown(
           </span>
           <ListBox.MenuIcon isOpen={isOpen} translateWithId={translateWithId} />
         </button>
-        <ListBox.Menu {...getMenuProps()}>
+        <ListBox.Menu aria-label={ariaLabelForMenu} {...getMenuProps()}>
           {isOpen &&
             items.map((item, index) => {
               const itemProps = getItemProps({ item, index });
@@ -223,6 +229,11 @@ Dropdown.propTypes = {
    * 'aria-label' of the ListBox component.
    */
   ariaLabel: PropTypes.string,
+
+  /**
+   * 'aria-label' of the ListBox Menu component.
+   */
+  ariaLabelMenu: PropTypes.string,
 
   /**
    * Provide a custom className to be applied on the bx--dropdown node

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
@@ -278,6 +278,7 @@ exports[`Dropdown should render custom item components 1`] = `
         </button>
         <ListBoxMenu
           aria-labelledby="downshift-6-label"
+          aria-label="downshift-menu-6-label"
           id="downshift-6-menu"
           onBlur={[Function]}
           onKeyDown={[Function]}

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
@@ -278,7 +278,6 @@ exports[`Dropdown should render custom item components 1`] = `
         </button>
         <ListBoxMenu
           aria-labelledby="downshift-6-label"
-          aria-label="downshift-menu-6-label"
           id="downshift-6-menu"
           onBlur={[Function]}
           onKeyDown={[Function]}

--- a/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
+++ b/packages/react/src/components/Dropdown/__snapshots__/Dropdown-test.js.snap
@@ -126,6 +126,7 @@ exports[`Dropdown should render 1`] = `
           </ListBoxMenuIcon>
         </button>
         <ListBoxMenu
+          aria-label="Dropdown menu list box"
           aria-labelledby="downshift-0-label"
           id="downshift-0-menu"
           onBlur={[Function]}
@@ -135,6 +136,7 @@ exports[`Dropdown should render 1`] = `
           tabIndex={-1}
         >
           <div
+            aria-label="Dropdown menu list box"
             aria-labelledby="downshift-0-label"
             className="bx--list-box__menu"
             id="downshift-0-menu"
@@ -277,6 +279,7 @@ exports[`Dropdown should render custom item components 1`] = `
           </ListBoxMenuIcon>
         </button>
         <ListBoxMenu
+          aria-label="Dropdown menu list box"
           aria-labelledby="downshift-6-label"
           id="downshift-6-menu"
           onBlur={[Function]}
@@ -286,6 +289,7 @@ exports[`Dropdown should render custom item components 1`] = `
           tabIndex={-1}
         >
           <div
+            aria-label="Dropdown menu list box"
             aria-labelledby="downshift-6-label"
             className="bx--list-box__menu"
             id="downshift-6-menu"
@@ -586,6 +590,7 @@ exports[`Dropdown should render with strings as items 1`] = `
           </ListBoxMenuIcon>
         </button>
         <ListBoxMenu
+          aria-label="Dropdown menu list box"
           aria-labelledby="downshift-4-label"
           id="downshift-4-menu"
           onBlur={[Function]}
@@ -595,6 +600,7 @@ exports[`Dropdown should render with strings as items 1`] = `
           tabIndex={-1}
         >
           <div
+            aria-label="Dropdown menu list box"
             aria-labelledby="downshift-4-label"
             className="bx--list-box__menu"
             id="downshift-4-menu"

--- a/packages/react/src/components/Pagination/Pagination-story.js
+++ b/packages/react/src/components/Pagination/Pagination-story.js
@@ -22,6 +22,11 @@ const props = () => ({
   disabled: boolean('Disable page inputs (disabled)', false),
   page: number('The current page (page)', 1),
   totalItems: number('Total number of items (totalItems)', 103),
+  menuPlacement: array('Choices of `menuPlacement` (menuPlacement)', [
+    'auto',
+    'top',
+    'bottom',
+  ]),
   pagesUnknown: boolean('Total number of items unknown (pagesUnknown)', false),
   pageInputDisabled: boolean(
     'Disable page input (pageInputDisabled)',

--- a/packages/react/src/components/Pagination/Pagination.js
+++ b/packages/react/src/components/Pagination/Pagination.js
@@ -100,7 +100,7 @@ export default class Pagination extends Component {
     itemsPerPageText: PropTypes.string,
 
     /**
-     * The placement of dropdwon either in top or bottom direction. By default its auto.
+     * The placement of dropdown either in top or bottom direction. By default its auto.
      */
     menuPlacement: PropTypes.oneOf(['auto', 'top', 'bottom']),
 


### PR DESCRIPTION
Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- Table Expand Row Table cell scope attribute
-  Updated Aria Label for Dropdown Menu

**Removed**

- Table Expand Row Table cell headers attribute

#### Testing / Reviewing

By default adding some expandHeader prop led to accessibility issue so added condition above and also added scope as row for the expand row table cell.
